### PR TITLE
traceapp: add support for smaller screen sizes.

### DIFF
--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -42,13 +42,19 @@
 
 <script type="text/javascript">
  var data = {{.VisData}};
- var width = 2000;
+ var width = $(".container").width();
+
+ // em converts the input (in em units) to pixels units and returns it.
+ function em(emUnits) {
+   var fontSize = parseFloat($('body').css('font-size'));
+   return fontSize * emUnits;
+ }
 
  function timelineHover() {
    var chart = d3.timeline()
                  .width(width)
                  .stack()
-                 .margin({left:70, right:30, top:0, bottom:0})
+                 .margin({left:em(6), right:0, top:0, bottom:0})
                  .hover(function (d, i, datum) {
                    // d is the current rendering object
                    // i is the index during d3 rendering


### PR DESCRIPTION
With this change we based the timeline' width on the container' width
which allows it to adapt to various different screen sizes (as bootstrap
keeps the container size consistent using @media tags).

For the margin, we convert em units to pixels using the body's font-size.

Before & after screenshots on my small (~13inch) laptop screen:

Before: ![before](https://cloud.githubusercontent.com/assets/3173176/5867450/ac8b9618-a259-11e4-8b38-d13f6a9d1877.png)

After: 
![after](https://cloud.githubusercontent.com/assets/3173176/5867454/b9ba18d2-a259-11e4-8a36-5bc3df9ced79.png)

