### PR TITLE
traceapp: Fix display of traces that contain no TimespanEvent's

### DIFF
--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -96,7 +96,9 @@
    });
  }
 
- timelineHover();
+ if(data != null) {
+   timelineHover();
+ }
 </script>
 
 <ul class="traces">

--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -50,26 +50,50 @@
    return fontSize * emUnits;
  }
 
+ // numFromEnd returns the number from the end of the potentially garbage
+ // string, e.g. "timelineItem_1443" -> 1443
+ function numFromEnd(str) {
+   return parseInt(str.match(/(\d+)$/)[0], 10);
+ }
+
  function timelineHover() {
+   var timespanHover = function(chart, index) {
+     var div = $('#hoverRes');
+     var colors = chart.colors();
+     div.find('.coloredDiv').css('background-color', colors(index));
+     div.find('#name').text(data[index].label);
+   }
+
    var chart = d3.timeline()
                  .width(width)
                  .stack()
                  .margin({left:em(6), right:0, top:0, bottom:0})
-                 .hover(function (d, i, datum) {
-                   // d is the current rendering object
-                   // i is the index during d3 rendering
-                   // datum is the id object
-                   var div = $('#hoverRes');
-                   var colors = chart.colors();
-                   div.find('.coloredDiv').css('background-color', colors(i))
-                   div.find('#name').text(datum.label);
-                 })
+                 .hover(function (d, i, datum) { timespanHover(chart, i) })
                  .click(function (d, i, datum) {
                    window.location.href = datum.url;
                    //alert(JSON.stringify(datum.rawData, null, 2));
                  });
    var svg = d3.select(".trace-timeline").append("svg").attr("width", width)
                .datum(data).call(chart);
+
+   // Make text on each timeline element click-able. d3-timeline.js doesn't
+   // seem to have a way to support this easily.
+   //
+   // We do this by selecting the text element, finding the prev element (the
+   // SVG rect), and then parsing the ID (which looks like: "timelineItem_1").
+   //
+   // The last number of that is the index into our data.
+   $(".trace-timeline g>text").each(function() {
+     $(this).hover(function() {
+       var index = numFromEnd($(this).prev().attr('id'));
+       timespanHover(chart, index);
+     });
+
+     $(this).click(function() {
+       var index = numFromEnd($(this).prev().attr('id'));
+       window.location.href = data[index].url;
+     });
+   });
  }
 
  timelineHover();

--- a/traceapp/vis.go
+++ b/traceapp/vis.go
@@ -89,6 +89,12 @@ func (a *App) d3timelineInner(t *apptrace.Trace, depth int) ([]timelineItem, err
 			ts.Label = fmt.Sprintf("%s (%s)", item.Label, msec)
 		}
 	}
+	if len(item.Times) == 0 {
+		// Items with a null times array will crash d3-timeline.js as it tries
+		// to iterate over it. This means the trace doesn't have a single
+		// TimespanEvent and is thus invalid.
+		return nil, nil
+	}
 	items = append(items, item)
 
 	for _, child := range t.Sub {


### PR DESCRIPTION
This can be merged after #5 is merged (or I'll re-base and resend).

This change helps #6 by properly display (and not crash JS) when displaying traces that do not contain TimespanEvent's in them (as currently generated by `--sample-data`). See the commit (of same name) for more details.

Before we had:
![before](https://cloud.githubusercontent.com/assets/3173176/5869430/4cef31e8-a276-11e4-94d1-833d3dc8f621.png)

Due to:
![image](https://cloud.githubusercontent.com/assets/3173176/5869426/412f0d56-a276-11e4-9090-9fcdfd05316c.png)

After this change:
![after](https://cloud.githubusercontent.com/assets/3173176/5869445/665ff266-a276-11e4-91ae-60c9d4c27aac.png)
