### PR TITLE
Replace mockCollector with collectorFunc.

### DIFF
--- a/recorder_test.go
+++ b/recorder_test.go
@@ -14,16 +14,14 @@ func TestRecorder(t *testing.T) {
 
 	calledCollect := 0
 	var anns Annotations
-	c := mockCollector{
-		Collect_: func(spanID SpanID, as ...Annotation) error {
-			calledCollect++
-			if spanID != id {
-				t.Errorf("Collect: got spanID arg %v, want %v", spanID, id)
-			}
-			anns = append(anns, as...)
-			return nil
-		},
-	}
+	c := collectorFunc(func(spanID SpanID, as ...Annotation) error {
+		calledCollect++
+		if spanID != id {
+			t.Errorf("Collect: got spanID arg %v, want %v", spanID, id)
+		}
+		anns = append(anns, as...)
+		return nil
+	})
 
 	r := NewRecorder(id, c)
 
@@ -47,12 +45,10 @@ func TestRecorder(t *testing.T) {
 func TestRecorder_Errors(t *testing.T) {
 	collectErr := errors.New("Collect error")
 	calledCollect := 0
-	c := mockCollector{
-		Collect_: func(spanID SpanID, as ...Annotation) error {
-			calledCollect++
-			return collectErr
-		},
-	}
+	c := collectorFunc(func(spanID SpanID, as ...Annotation) error {
+		calledCollect++
+		return collectErr
+	})
 
 	r := NewRecorder(SpanID{}, c)
 


### PR DESCRIPTION
While looking through the tests I noticed a rather non-idiomatic `mockCollector` type used throughout the tests:

```
type mockCollector struct {
	Collect_ func(SpanID, ...Annotation) error
}

func (c mockCollector) Collect(id SpanID, as ...Annotation) error {
	return c.Collect_(id, as...)
}
```

Replace it with a more idiomatic pattern employed by `net/http.HandlerFunc`:

```
// collectorFunc implements the Collector interface by calling the function.
type collectorFunc func(SpanID, ...Annotation) error

// Collect implements the Collector interface by calling the function itself.
func (c collectorFunc) Collect(id SpanID, as ...Annotation) error {
	return c(id, as...)
}
```