### PR TITLE
Add some missing function documentation.

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -189,6 +189,8 @@ type RemoteCollector struct {
 	Debug bool
 }
 
+// Collect implements the Collector interface by sending the events that
+// occured in the span to the remote collector server (see CollectorServer).
 func (rc *RemoteCollector) Collect(span SpanID, anns ...Annotation) error {
 	return rc.collectAndRetry(collectPacket{span, anns})
 }

--- a/recorder.go
+++ b/recorder.go
@@ -51,6 +51,8 @@ func (r *Recorder) Log(msg string) {
 	r.Event(Log(msg))
 }
 
+// Event records any event that implements the Event, TimespanEvent, or
+// TimestampedEvent interfaces.
 func (r *Recorder) Event(e Event) {
 	as, err := MarshalEvent(e)
 	if err != nil {

--- a/store.go
+++ b/store.go
@@ -58,6 +58,8 @@ var _ interface {
 	Queryer
 } = (*MemoryStore)(nil)
 
+// Collect implements the Collector interface by collecting the events that
+// occured in the span in-memory.
 func (ms *MemoryStore) Collect(id SpanID, as ...Annotation) error {
 	ms.Lock()
 	defer ms.Unlock()
@@ -189,6 +191,9 @@ func (ms *MemoryStore) reattachChildren(dst, src *Trace) {
 	src.Sub = sub2
 }
 
+// Trace implements the Store interface by returning the Trace (a tree of
+// spans) for the given trace span ID or, if no such trace exists, by returning
+// ErrTraceNotFound.
 func (ms *MemoryStore) Trace(id ID) (*Trace, error) {
 	ms.Lock()
 	defer ms.Unlock()
@@ -204,6 +209,7 @@ func (ms *MemoryStore) traceNoLock(id ID) (*Trace, error) {
 	return t, nil
 }
 
+// Traces implements the Queryer interface.
 func (ms *MemoryStore) Traces() ([]*Trace, error) {
 	ms.Lock()
 	defer ms.Unlock()
@@ -219,6 +225,8 @@ func (ms *MemoryStore) Traces() ([]*Trace, error) {
 	return ts, nil
 }
 
+// Delete implements the DeleteStore interface by deleting the traces given by
+// their span ID's from this in-memory store.
 func (ms *MemoryStore) Delete(traces ...ID) error {
 	ms.Lock()
 	defer ms.Unlock()


### PR DESCRIPTION
Add some missing function' documentation, which was identified as missing by `golint`:

```
$ golint .
collector.go:192:1: exported method RemoteCollector.Collect should have comment or be unexported
recorder.go:54:1: exported method Recorder.Event should have comment or be unexported
store.go:61:1: exported method MemoryStore.Collect should have comment or be unexported
store.go:192:1: exported method MemoryStore.Trace should have comment or be unexported
store.go:207:1: exported method MemoryStore.Traces should have comment or be unexported
store.go:222:1: exported method MemoryStore.Delete should have comment or be unexported
```