### PR TITLE
sqltrace: add basic package documentation

### DIFF
--- a/sqltrace/sql.go
+++ b/sqltrace/sql.go
@@ -1,3 +1,4 @@
+// Package sqltrace implements utility types for tracing SQL queries.
 package sqltrace
 
 import (
@@ -6,6 +7,8 @@ import (
 	"sourcegraph.com/sourcegraph/apptrace"
 )
 
+// SQLEvent is an SQL query event for use with apptrace. It's primary function
+// is to measure the time between when the query is sent and later received.
 type SQLEvent struct {
 	SQL        string
 	Tag        string
@@ -13,9 +16,16 @@ type SQLEvent struct {
 	ClientRecv time.Time
 }
 
+// Schema implements the apptrace Event interface by returning this event's
+// constant schema string, "SQL".
 func (SQLEvent) Schema() string { return "SQL" }
 
+// Start implements the apptrace TimespanEvent interface by returning the time
+// at which the SQL query was sent out.
 func (e SQLEvent) Start() time.Time { return e.ClientSend }
-func (e SQLEvent) End() time.Time   { return e.ClientRecv }
+
+// End implements the apptrace TimespanEvent interface by returning the time at
+// which the SQL query returned / was received.
+func (e SQLEvent) End() time.Time { return e.ClientRecv }
 
 func init() { apptrace.RegisterEvent(SQLEvent{}) }


### PR DESCRIPTION
This just adds some trivial documentation that is currently missing from the package.

Usage examples will come at a later time.