### PR TITLE
traceapp: pad the text displayed on the hover resolver

### DIFF
--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -35,8 +35,12 @@
    -o-transform: translate(0px,30px); /* Opera */
    -moz-transform: translate(0px,30px); /* Firefox */
  }
- .coloredDiv {
+ #hoverRes .coloredDiv {
    height:20px; width:20px; float:left;
+ }
+ #hoverRes #name {
+   display: inline-block;
+   margin-left: 0.3em;
  }
 </style>
 


### PR DESCRIPTION
This change primarily pads the text displayed to the right of the hover resolver.

Additionally, it also replaces the CSS line:
```
.coloredDiv {
```

With a more correct (unaffecting outside `#hoverRes`) line:

```
 #hoverRes .coloredDiv {
```

Before (note circled area):

![image](https://cloud.githubusercontent.com/assets/3173176/5965984/bed20af0-a7bd-11e4-83d8-be0ad7b736f5.png)

After:

![image](https://cloud.githubusercontent.com/assets/3173176/5965987/c87e2944-a7bd-11e4-8d70-df857636ded7.png)

