### PR TITLE
Add support for a context menu that can show and hide specific spans.

### DIFF
--- a/traceapp/tmpl/root.html
+++ b/traceapp/tmpl/root.html
@@ -22,6 +22,7 @@
 <h2>Getting Started</h2>
 <div class="sub">
 	<p>To get started, click on the <em>Traces</em> tab at the top of this page. When a trace is collected it will show up there.</p>
+    <p>Tip: Try right clicking on a span to bring up the context menu!</p>
 </div>
 
 <hr/>

--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -13,6 +13,19 @@
 </div>
 </div>
 
+
+<div id="contextMenu" class="dropdown clearfix">
+  <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu" style="display:block;position:static;margin-bottom:5px;">
+    <li role="presentation" class="name dropdown-header"></li>
+
+    <li><a tabindex="-1" data-action="show-children" href="#">Show Children</a></li>
+    <li><a tabindex="-1" data-action="hide-children" href="#">Hide Children</a></li>
+
+    <li><a tabindex="-1" href="#" data-action="close">Close</a></li>
+  </ul>
+</div>
+
+
 <style type="text/css">
  .axis path,
  .axis line {
@@ -42,6 +55,21 @@
    display: inline-block;
    margin-left: 0.3em;
  }
+ #contextMenu {
+   font-family: sans-serif;
+   font-size: 12px;
+   position: absolute;
+   display:none;
+ }
+ #contextMenu .dropdown-menu>li>span {
+   display: block;
+   padding: 3px 20px;
+   clear: both;
+   font-weight: 400;
+   line-height: 1.42857143;
+   color: #333;
+   white-space: nowrap;
+ }
 </style>
 
 <script type="text/javascript">
@@ -60,14 +88,77 @@
    return parseInt(str.match(/(\d+)$/)[0], 10);
  }
 
+ // setChildrenVisible walks through the data and finds all children (including
+ // distant ones) of the given spanID. It marks each one as visible (true or
+ // false).
+ function setChildrenVisible(spanID, visible) {
+   $.each(data, function(i, other) {
+     if(other.parentSpanID != spanID) {
+       return;
+     }
+     other.visible = visible;
+     setChildrenVisible(other.spanID, visible);
+   });
+ }
+
+ // When the user presses the Close button in the context menu, we hide it. We
+ // declare this as a separate function so that other context menu items can
+ // quickly hide the context menu as well (see below).
+ function ctxMenuActionClose(e) {
+   e.preventDefault();
+   $("#contextMenu").hide();
+ }
+ $('#contextMenu a[data-action="close"]').on("click", ctxMenuActionClose);
+
+ // ctxMenuActionShowHide is the implementation for the context menu's Show
+ // Children and Hide Children buttons.
+ function ctxMenuActionShowHide(e, visible) {
+   ctxMenuActionClose(e);
+   var spanID = $("#contextMenu").data("dataObject").spanID;
+   setChildrenVisible(spanID, visible)
+   timelineHover();
+ }
+
+ // Event handlers for each context menu Show/Hide button.
+ $('#contextMenu a[data-action="show-children"]').on("click", function(e) { ctxMenuActionShowHide(e, true) });
+ $('#contextMenu a[data-action="hide-children"]').on("click", function(e) { ctxMenuActionShowHide(e, false) });
+
+ function ctxMenuOpen(e, datum, obj) {
+   $("#contextMenu").data("dataObject", obj);
+   $("#contextMenu .name").html(datum.label);
+   $("#contextMenu").css({
+     display: "block",
+     left: e.pageX,
+     top: e.pageY
+   });
+   return false;
+ }
+
  function timelineHover() {
+   // When rebuilding the timeline to account for changes, we must first empty
+   // it completely.
+   $(".trace-timeline").empty();
+
+   // Copy just the visible objects of the data for passing into d3-timeline.
+   var visibleData = [];
+   $.each(data, function(i, obj) {
+     if(!obj.visible) {
+       return;
+     }
+     visibleData.push(obj);
+   });
+   if(visibleData.length == 0) {
+     return;
+   }
+
    var timespanHover = function(chart, index) {
      var div = $('#hoverRes');
      var colors = chart.colors();
      div.find('.coloredDiv').css('background-color', colors(index));
-     div.find('#name').text(data[index].label);
+     div.find('#name').text(visibleData[index].label);
    }
 
+   // Initialize the timeline chart.
    var chart = d3.timeline()
                  .width(width)
                  .stack()
@@ -78,7 +169,7 @@
                    //alert(JSON.stringify(datum.rawData, null, 2));
                  });
    var svg = d3.select(".trace-timeline").append("svg").attr("width", width)
-               .datum(data).call(chart);
+               .datum(visibleData).call(chart);
 
    // Make text on each timeline element click-able. d3-timeline.js doesn't
    // seem to have a way to support this easily.
@@ -86,17 +177,21 @@
    // We do this by selecting the text element, finding the prev element (the
    // SVG rect), and then parsing the ID (which looks like: "timelineItem_1").
    //
-   // The last number of that is the index into our data.
+   // The last number of that is the index into our visibleData.
    $(".trace-timeline g>text").each(function() {
+     var index = numFromEnd($(this).prev().attr('id'));
      $(this).hover(function() {
-       var index = numFromEnd($(this).prev().attr('id'));
        timespanHover(chart, index);
      });
-
      $(this).click(function() {
-       var index = numFromEnd($(this).prev().attr('id'));
-       window.location.href = data[index].url;
+       window.location.href = visibleData[index].url;
      });
+
+     // When there is a contextmenu (e.g. right click) event we open the
+     // context menu on the timespan rectangle.
+     var datum = d3.select($(this).prev()[0]).data()[0];
+     $(this).on("contextmenu", function(e) { return ctxMenuOpen(e, datum, visibleData[index]) });
+     $(this).prev().on("contextmenu", function(e) { return ctxMenuOpen(e, datum, visibleData[index]) });
    });
  }
 

--- a/traceapp/vis.go
+++ b/traceapp/vis.go
@@ -12,11 +12,13 @@ import (
 )
 
 type timelineItem struct {
-	Label  string                  `json:"label"`
-	Times  []*timelineItemTimespan `json:"times"`
-	Data   map[string]string       `json:"rawData"`
-	SpanID string                  `json:"spanID"`
-	URL    string                  `json:"url"`
+	Label        string                  `json:"label"`
+	Times        []*timelineItemTimespan `json:"times"`
+	Data         map[string]string       `json:"rawData"`
+	SpanID       string                  `json:"spanID"`
+	ParentSpanID string                  `json:"parentSpanID"`
+	URL          string                  `json:"url"`
+	Visible      bool                    `json:"visible"`
 }
 
 type timelineItemTimespan struct {
@@ -57,6 +59,12 @@ func (a *App) d3timelineInner(t *apptrace.Trace, depth int) ([]timelineItem, err
 		Data:   t.Annotations.StringMap(),
 		SpanID: t.Span.ID.Span.String(),
 		URL:    u.String(),
+	}
+	if t.Span.ID.Parent != 0 {
+		item.ParentSpanID = t.Span.ID.Parent.String()
+	}
+	if depth <= 1 {
+		item.Visible = true
 	}
 	for _, e := range events {
 		if e, ok := e.(apptrace.TimespanEvent); ok {


### PR DESCRIPTION
Add support for a context menu that can show and hide specific spans.

By default, only the immediate children of the trace are visible, for example:
***
![image](https://cloud.githubusercontent.com/assets/3173176/5984781/e1533732-a896-11e4-8493-a3c0a84d5840.png)
***
Instead of:
***
![image](https://cloud.githubusercontent.com/assets/3173176/5984794/f6f093be-a896-11e4-8021-b90565fdb666.png)
***
You can then right click (context menu button) on any timespan rectangle (e.g. `Request`) to bring up the context menu:
***
![image](https://cloud.githubusercontent.com/assets/3173176/5984835/7966d31c-a897-11e4-98d9-bf9f31c4c4ed.png)
***
Clicking `Show Children` or `Hide Children` causes _all immediate and distant children of that span to be hidden/shown_. For example clicking `Show Children` on the `Request` span:
***
![image](https://cloud.githubusercontent.com/assets/3173176/5984879/fa40957c-a897-11e4-844b-72b0cecce10d.png)
***
And then `Hide Children` on `Moonuiburg`:
***
![image](https://cloud.githubusercontent.com/assets/3173176/5984910/47664dba-a898-11e4-8258-e6d7e3375b54.png)