### PR TITLE
cmd/apptrace: Have --sample-data generate fake SQL and tag info.

### DIFF
--- a/cmd/apptrace/sample_data.go
+++ b/cmd/apptrace/sample_data.go
@@ -61,6 +61,8 @@ func fakeEvent(name string, i int) *sqltrace.SQLEvent {
 	return &sqltrace.SQLEvent{
 		ClientSend: initTime.Add(t[i][0] * time.Millisecond),
 		ClientRecv: initTime.Add(t[i][1] * time.Millisecond),
+		SQL:        "SELECT * FROM table_name;",
+		Tag:        fmt.Sprintf("fakeTag%d", i),
 	}
 }
 


### PR DESCRIPTION
This change has `--sample-data` generate fake SQL queries and tag information, it will help demonstrate the searching abilities I plan on adding soon.

Before:
***

![image](https://cloud.githubusercontent.com/assets/3173176/5986025/98e8ff3c-a8a9-11e4-8d39-bf78ead4f8f6.png)


After:
***

![image](https://cloud.githubusercontent.com/assets/3173176/5986012/5b928b6c-a8a9-11e4-943c-64c95d66ec93.png)
