### PR TITLE
traceapp: perform fuzzy search on all rawData keys.

### DIFF
--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -120,15 +120,10 @@
  // specifically, the names and tags) and hides all children elements that do
  // not match.
  function filterChildrenFuzzy(spanID, filter) {
-   // Use fuse to fuzzy-search through our dataset with the given filter.
-   var options = {
-     caseSensitive: false,
-     shouldSort: true,
-     threshold: 0.3, // A lower threshold is more strict, higher is less.
-     keys: ["rawData.Name", "rawData.Tag"] // Data fields to search on.
-   };
-   var fuse = new Fuse(data, options);
-   var results = fuse.search(filter);
+   // Fuse has a limitation of 32 character search pattern strings, so we just
+   // slice to 32 incase someone enters more (which would cause Fuse to raise
+   // an exception).
+   filter = filter.slice(0, 32);
 
    // Recursively descend into each span showing and hiding each one based on
    // our search results.
@@ -141,16 +136,20 @@
          return;
        }
 
-       // Depending on whether or not the span showed up in our fuzzy search
-       // results, we show or hide it.
-       other.visible = false;
-       $.each(results, function(i, result) {
-         if(result.spanID != other.spanID) {
-           return;
-         }
-         other.visible = true;
-         return false; // stop the search.
+       // Perform a fuzzy search on this spans' keys. We do this as not all
+       // spans have identical keys to search on, and Fuse wants specific keys
+       // to search on.
+       var fuse = new Fuse([other.rawData], {
+         caseSensitive: false,
+         shouldSort: true,
+         threshold: 0.3,                   // A lower threshold is more strict, higher is less.
+         keys: Object.keys(other.rawData), // Data fields to search on.
        });
+       var results = fuse.search(filter);
+
+       // Depending on whether or not the fuzzy search on this span turned up
+       // any results, the span is visible or hidden.
+       other.visible = results.length > 0;
 
        // Descend into that span's children.
        descend(other.spanID);


### PR DESCRIPTION
With this change, you can now fully strict or fuzzy search against all of
the keys in the spans. A fuzzy search for e.g. "200" would turn up results
properly now.

Also, we implicitly limit the filter/search string to 32 characters when
fuzzy searching as Fuse is limited to that, and will raise an exception
otherwise.

The tactic used for searching against all keys, is on a per-object (i.e.
per-span) basis. This means there is one fuse search per span object. I
also tried a single fuse search, but against the uniform (i.e. common) set
of keys shared by all the objects, but not all spans share the same set of
keys (and Fuse wants a strict set of keys to search against, specifically).

A more proper long-term fix for both of these would be to: modify Fuse to
search all object keys (when none are specified in the options map), and
make Fuse responsible for searching for patterns greater than 32 characters
(whether that means slicing to 32 implicitly as we do here, or searching
for every 32-byte consecutive sets in the pattern string).

Filtering the following trace:
***
![image](https://cloud.githubusercontent.com/assets/3173176/6071370/736b8592-ad52-11e4-9969-f4af73ff29b6.png)
***
For just `hello` (which some spans have as fake messages) produces identical results to a strict `Msg:"hello"` filter:
***
![image](https://cloud.githubusercontent.com/assets/3173176/6071393/9f8bc088-ad52-11e4-90e9-969cdc6620f8.png)