### PR TITLE
traceapp: use schema-less ("//" vs "https://") includes for JS/CSS

### DIFF
--- a/traceapp/tmpl/layout.html
+++ b/traceapp/tmpl/layout.html
@@ -22,11 +22,11 @@
      .d9 { background-color: #cc1c1c; }
      .d10 { background-color: #cc0e0e; }
     </style>
-    <script src="https://code.jquery.com/jquery-2.1.1.js"></script>
+    <script src="//code.jquery.com/jquery-2.1.1.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.4.13/d3.js"></script>
-    <script src="https://rawgit.com/jiahuang/d3-timeline/master/src/d3-timeline.js"></script>
-    <script src="https://rawgit.com/krisk/fuse/master/src/fuse.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.4.13/d3.js"></script>
+    <script src="//rawgit.com/jiahuang/d3-timeline/master/src/d3-timeline.js"></script>
+    <script src="//rawgit.com/krisk/fuse/master/src/fuse.min.js"></script>
   </head>
   <body>
     <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">


### PR DESCRIPTION
This has the browser use the appropriate schema whether on HTTPS or HTTP, and is generally better in all cases (e.g. connecting via a proxy or some other weird network which blocks HTTP(S) connections).

Primarily I employed this change because it is strange to use an inconsistent pattern in multiple places, and it seems like `//` is generally accepted over a specific one (or instead of mixing and matching).