### PR TITLE
Add the ability to switch to a profiling view.

### DIFF
--- a/traceapp/prof.go
+++ b/traceapp/prof.go
@@ -1,0 +1,89 @@
+package traceapp
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"time"
+
+	"sourcegraph.com/sourcegraph/apptrace"
+)
+
+type profile struct {
+	Name                        string
+	Time, TimeChildren, TimeCum int64
+}
+
+// calcProfile calculates a profile for the given trace and appends it to the
+// given buffer (buf), which is then returned (prof). If an error is returned,
+// all other returned values are nil. The childProf is literally the *profile
+// associated with the given trace (t).
+func (a *App) calcProfile(buf []*profile, t *apptrace.Trace) (prof []*profile, childProf *profile, err error) {
+	// Unmarshal the trace's span events.
+	var events []apptrace.Event
+	if err := apptrace.UnmarshalEvents(t.Span.Annotations, &events); err != nil {
+		return nil, nil, err
+	}
+
+	// Initialize the span's profile structure. We use either the span's given
+	// name, or it's ID as a string if it has no given name.
+	p := &profile{
+		Name: t.Span.Name(),
+	}
+	if len(p.Name) == 0 {
+		p.Name = t.Span.ID.Span.String()
+	}
+	buf = append(buf, p)
+
+	// If the span has a timespan event, we measure it's time.
+	for _, ev := range events {
+		ts, ok := ev.(apptrace.TimespanEvent)
+		if ok {
+			p.Time = int64(ts.End().Sub(ts.Start()) / time.Millisecond)
+			break
+		}
+	}
+
+	// TimeChildren is our time + the children's time.
+	p.TimeChildren = p.Time
+
+	// The cumulative time is our time + all children's time.
+	p.TimeCum = p.Time
+
+	// Descend recursively into each sub-trace and calculate the profile for
+	// each child span.
+	for _, child := range t.Sub {
+		buf, childProf, err = a.calcProfile(buf, child)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Aggregate our direct children's time.
+		p.TimeChildren += childProf.Time
+
+		// As our child's profile has the cumulative time (which is initially,
+		// it's self time) -- we can simply aggregate it here and we have our
+		// trace's cumulative time (i.e. it is effectively recursive).
+		p.TimeCum += childProf.TimeCum
+	}
+	return buf, p, nil
+}
+
+// profile generates and encodes the given trace as JSON to the given writer.
+func (a *App) profile(t *apptrace.Trace, out io.Writer) error {
+	// Generate the profile.
+	prof, _, err := a.calcProfile(nil, t)
+	if err != nil {
+		return err
+	}
+
+	// Encode to JSON.
+	j, err := json.Marshal(prof)
+	if err != nil {
+		return err
+	}
+
+	// Write out.
+	_, err = io.Copy(out, bytes.NewReader(j))
+	return err
+}

--- a/traceapp/router.go
+++ b/traceapp/router.go
@@ -9,10 +9,12 @@ import (
 )
 
 const (
-	RootRoute      = "traceapp.root"       // route name for root
-	TraceRoute     = "traceapp.trace"      // route name for a single trace page
-	TraceSpanRoute = "traceapp.trace.span" // route name for a single trace sub-span page
-	TracesRoute    = "traceapp.traces"     // route name for traces page
+	RootRoute             = "traceapp.root"               // route name for root
+	TraceRoute            = "traceapp.trace"              // route name for a single trace page
+	TraceSpanRoute        = "traceapp.trace.span"         // route name for a single trace sub-span page
+	TraceProfileRoute     = "traceapp.trace.profile"      // route name for a JSON trace profile
+	TraceSpanProfileRoute = "traceapp.trace.span.profile" // route name for a JSON trace sub-span profile
+	TracesRoute           = "traceapp.traces"             // route name for traces page
 )
 
 type Router struct{ r *mux.Router }
@@ -24,6 +26,8 @@ func NewRouter(base *mux.Router) *Router {
 	}
 	base.Path("/").Methods("GET").Name(RootRoute)
 	base.Path("/traces/{Trace}").Methods("GET").Name(TraceRoute)
+	base.Path("/traces/{Trace}/profile").Methods("GET").Name(TraceProfileRoute)
+	base.Path("/traces/{Trace}/{Span}/profile").Methods("GET").Name(TraceSpanProfileRoute)
 	base.Path("/traces/{Trace}/{Span}").Methods("GET").Name(TraceSpanRoute)
 	base.Path("/traces").Methods("GET").Name(TracesRoute)
 	return &Router{base}
@@ -46,4 +50,15 @@ func (r *Router) URLToTrace(id apptrace.ID) (*url.URL, error) {
 // URLToTraceSpan constructs a URL to a sub-span in a trace.
 func (r *Router) URLToTraceSpan(trace, span apptrace.ID) (*url.URL, error) {
 	return r.r.Get(TraceSpanRoute).URL("Trace", trace.String(), "Span", span.String())
+}
+
+// URLToTraceProfile constructs a URL to a trace's JSON profile.
+func (r *Router) URLToTraceProfile(trace apptrace.ID) (*url.URL, error) {
+	return r.r.Get(TraceProfileRoute).URL("Trace", trace.String())
+}
+
+// URLToTraceSpanProfile constructs a URL to a sub-span's JSON profile in a
+// trace.
+func (r *Router) URLToTraceSpanProfile(trace, span apptrace.ID) (*url.URL, error) {
+	return r.r.Get(TraceSpanProfileRoute).URL("Trace", trace.String(), "Span", span.String())
 }

--- a/traceapp/tmpl/layout.html
+++ b/traceapp/tmpl/layout.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon"> 
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.6.0/bootstrap-table.min.css">
     <style>
      body { padding-top: 50px; }
      .d0 { background-color: #bbb; }
@@ -24,6 +25,7 @@
     </style>
     <script src="//code.jquery.com/jquery-2.1.1.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.3.1/js/bootstrap.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/bootstrap-table/1.6.0/bootstrap-table.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.4.13/d3.js"></script>
     <script src="//rawgit.com/jiahuang/d3-timeline/master/src/d3-timeline.js"></script>
     <script src="//rawgit.com/krisk/fuse/master/src/fuse.min.js"></script>

--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -72,6 +72,7 @@
    font-size: 12px;
    position: absolute;
    display: none;
+   z-index: 100;
  }
  #contextMenu .dropdown-menu>li>span {
    display: block;
@@ -339,7 +340,51 @@
  }
 </script>
 
-<ul class="traces">
+
+<!-- Trace Table -->
+<style type="text/css">
+ .viewMode {
+   padding-top: 1em;
+   padding-bottom: 1em;
+ }
+ #profileView {
+   display: none;
+ }
+</style>
+
+<!-- Justified radio-buttons for switching between data and profile views -->
+<div class="viewMode btn-group btn-group-justified btn-group-xs" data-toggle="buttons" id="radioopt">
+  <label class="btn btn-primary active">
+    <input type="radio" name="view" id="btnDataView" value="Data View">Data View</input>
+  </label>
+  <label class="btn btn-primary">
+    <input type="radio" name="view" id="btnProfileView" value="Profile View">Profile View</input>
+  </label>
+</div>
+
+<!--
+ JavaScript code to hide and show the data / profile views depending on which
+ radio button is selected
+-->
+<script type="text/javascript">
+  $(".viewMode input:radio").change(function(){
+     var id = $(this).attr("id");
+     if(id == "btnDataView") {
+       $("#dataView").show();
+     } else {
+       $("#dataView").hide();
+     }
+
+     if(id == "btnProfileView") {
+       $("#profileView").show();
+     } else {
+       $("#profileView").hide();
+     }
+  });
+</script>
+
+<!-- The data view layout -->
+<ul id="dataView" class="traces">
   <li class="trace" id="span-{{.Trace.Span.ID.Span}}">
     {{if .Trace.Name}}
     <strong title="{{.Trace.ID}}">{{.Trace.Name}}</strong>
@@ -356,6 +401,30 @@
     {{end}}
   </li>
 </ul>
+
+<!-- The profile view layout -->
+<div id="profileView">
+  <table data-toggle="table" data-url="{{.ProfileURL}}" class="table table-condensed" data-height="299">
+    <thead>
+      <tr>
+        <th data-sortable="true" data-field="Name">Name</th>
+        <th data-sortable="true" data-field="Time">Time (ms)</th>
+        <th data-sortable="true" data-field="TimeChildren">Time + Children (ms)</th>
+        <th data-sortable="true" data-field="TimeCum">Cumulative Time (ms)</th>
+      </tr>
+    </thead>
+    <tbody>
+      <!-- Example data useful for previewing the table UI
+      <tr>
+        <td>/tmp?foo=true</td>
+        <td>1050</td>
+        <td>3000</td>
+        <td>23000</td>
+      </tr>
+      -->
+    </tbody>
+  </table>
+</div>
 
 {{end}}
 


### PR DESCRIPTION
This change adds the ability to switch between the current meta-data table view (which is the default):
***
![image](https://cloud.githubusercontent.com/assets/3173176/6087574/75fae736-ae0a-11e4-8246-e988f021ed07.png)
***
To a new profiling view with the ability to show you which requests took the most (self time, self+children time, or cumulative time):
***
![image](https://cloud.githubusercontent.com/assets/3173176/6087589/9f210276-ae0a-11e4-92af-65059653c4c5.png)
***
Clicking any of the table headers, for example `Time + Children (ms)`, sorts by that colum as you'd expect:
***
![image](https://cloud.githubusercontent.com/assets/3173176/6087615/02f6231c-ae0b-11e4-8774-f8ba6b0ca2a9.png)
***
If you click on a span in the timeline UI to narrow your view onto the sub-span, you can like-wise also view profiling information for just that sub-span:
***
![image](https://cloud.githubusercontent.com/assets/3173176/6087655/8ad80b2e-ae0b-11e4-86cb-d956dc4de497.png)
***

bootstrap-table.js (MIT licensed) is used to fetch and display the JSON profile data calculated on the Go web-server.

Additionally, two new public functions are exposed on `*traceapp.App`: `URLToTraceProfile` and `URLToTraceSpanProfile` which allow for the creation of URL's to root-trace and sub-span-trace profiles, respectively.