### PR TITLE
traceapp: Do not generate multiple timespan events for sub-traces.

### DIFF
--- a/traceapp/vis.go
+++ b/traceapp/vis.go
@@ -74,7 +74,7 @@ func (a *App) d3timelineInner(t *apptrace.Trace, depth int) ([]timelineItem, err
 				Start: start,
 				End:   end,
 			}
-			if depth == 0 {
+			if t.Span.ID.Parent == 0 {
 				ts.Label = e.Schema()
 				item.Times = append(item.Times, &ts)
 			} else {


### PR DESCRIPTION
Checking depth == 0 is not the correct check to perform when acting
on sub-traces. A better check is to see if there is a parent span
or not. By doing this we do not generate two separate times (and
inherently, labels), which otherwise makes them very hard to read.

Fixes #26

(see issue for before photo) after:

![image](https://cloud.githubusercontent.com/assets/3173176/6094342/b3ab86ec-aee3-11e4-9ec2-2822f53f7936.png)