### PR TITLE
traceapp: enable clicking on profile-view table rows (go to span page).

### DIFF
--- a/traceapp/tmpl/trace.html
+++ b/traceapp/tmpl/trace.html
@@ -439,5 +439,17 @@
   </table>
 </div>
 
+<!--
+ When clicking on a profile-view table row, we want it to redirect us to the
+ proper sub-span page.
+-->
+<script type="text/javascript">
+ $("#profileView .table").on('click-row.bs.table', function (e, row, $element) {
+   if(window.location.pathname != row.URL) {
+     window.location.href = row.URL;
+   }
+ });
+</script>
+
 {{end}}
 


### PR DESCRIPTION
This change enables clicking on table rows under profile-view. Clicking any row brings you to the span/sub-span page for that trace, as it would if you clicked it in the timeline. This allows one to find both the span ID as well as identify what span it is when e.g. names are the same or otherwise non-helpful.

Fixes #25