### PR TITLE
traceapp: generate profile times that exactly match the timeline.

### DIFF
--- a/traceapp/prof.go
+++ b/traceapp/prof.go
@@ -52,12 +52,17 @@ func (a *App) calcProfile(buf []*profile, t *apptrace.Trace) (prof []*profile, c
 	}
 	buf = append(buf, p)
 
-	// If the span has a timespan event, we measure it's time.
+	// Store the time for the largest timespan event the span has.
 	for _, ev := range events {
 		ts, ok := ev.(apptrace.TimespanEvent)
-		if ok {
-			p.Time = int64(ts.End().Sub(ts.Start()) / time.Millisecond)
-			break
+		if !ok {
+			continue
+		}
+		// To match the timeline properly we use floats and round up.
+		msf := float64(ts.End().Sub(ts.Start())) / float64(time.Millisecond)
+		ms := int64(msf + 0.5)
+		if ms > p.Time {
+			p.Time = ms
 		}
 	}
 


### PR DESCRIPTION
This change makes the profiling times be calculated as floating-point numbers and rounded up, as they are in the d3 timeline. This is both more accurate and less confusing to users overall.

With this change we also appropriately grab the largest of the timespan events, rather than just the first one. This matches how apptrace already sends the timespans to the template for rendering in the timeline.

Before (see incorrect profile vs timeline times):
***
![image](https://cloud.githubusercontent.com/assets/3173176/6094722/ba9d4952-aef4-11e4-9344-dc5dfaf00230.png)
***
After (see identical profile & timeline times):
***
![image](https://cloud.githubusercontent.com/assets/3173176/6094737/ec3f38da-aef4-11e4-81e0-b769d76fb385.png)
***